### PR TITLE
docs: Top level install & ethereum guide

### DIFF
--- a/docs/ethereum.md
+++ b/docs/ethereum.md
@@ -1,0 +1,115 @@
+# Connect to Ethereum
+
+`livepeer` requires access to an [Ethereum](https://ethereum.org/en/) network for typical usage.
+
+## Connecting to a network
+
+There are two ways you can connect to an Ethereum network: via a hosted API service or via your own self-hosted Ethereum node. Connecting to a hosted API service is recommended for users that are getting started and you always have the option to switch to your own node if later on.
+
+### Hosted API services
+
+Hosted API services run Ethereum nodes on behalf of their users. Popular services include [Infura](https://infura.io/) and [Alchemy](https://alchemyapi.io/). Be aware that these services have their own pricing plans. That being said, the latest versions of `livepeer` should be able to stay within the request limit for Infura's free tier at least for a single node.
+
+The following examples describe the required flags to connect to an Ethereum network via Infura (all other flags omitted):
+
+To connect to mainnet:
+
+```bash
+livepeer \
+    -network mainnet
+    -ethUrl https://mainnet.infura.io/v3/<PROJECT_ID> # Visit https://infura.io to obtain a PROJECT_ID
+```
+
+To connect to Rinkeby:
+
+```bash
+livepeer \
+    -network rinkeby
+    -ethUrl https://rinkeby.infura.io/v3/<PROJECT_ID> # Visit https://infura.io to obtain a PROJECT_ID
+```
+
+### Self-hosted Etherem nodes
+
+If you want to run your own Ethereum node, you can use one of the clients listed [here](https://docs.ethhub.io/using-ethereum/running-an-ethereum-node/). `geth` is recommended because it supports both mainnet and Rinkeby. Additionally, at this time `livepeer` has been the most thoroughly tested with `geth`.
+
+#### Geth
+
+1. Install `geth` using the [installation guide](https://geth.ethereum.org/docs/install-and-build/installing-geth)
+
+2. Sync `geth`. The following command will sync `geth` on mainnet:
+
+    ```bash
+    geth \
+        -rpc \
+        -rpcapi eth,net,web3 \
+        -rpcaddr <ADDRESS> # An address to bind on is required if geth is running on a different machine than livepeer
+    ```
+
+3. Wait until `geth` is fully synced. Check that syncing is complete using the Geth Javascript Console:
+
+    ```bash
+    geth attach http://localhost:8545
+    Welcome to the Geth JavaScript console!
+
+    instance: Geth/v1.9.0-stable-52f24617/linux-amd64/go1.12.7
+    coinbase: 0x0161e041aad467a890839d5b08b138c1e6373072
+    at block: 583 (Wed, 23 Oct 2019 17:41:00 EDT)
+    modules: debug:1.0 eth:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 txpool:1.0 web3:1.0
+
+    > eth.syncing
+    false
+    ```
+
+    `geth` will be done syncing when `eth.syncing` returns false.
+
+4. Connect `livepeer` to `geth` with the following flags (all other flags omitted):
+
+    ```bash
+    livepeer \
+        -network mainnet \
+        -ethUrl localhost:8545 # Assumes that geth is running on the same machine as livepeer
+    ```
+
+## Supported networks
+
+`livepeer` supports the networks listed below. The required flags for connecting to a network are described (all other flags are omitted).
+
+### Mainnet
+
+Mainnet is the production public network.
+
+```bash
+livepeer \
+    -network mainnet
+    -ethUrl <ETH_URL> # URL for mainnet provider
+```
+
+### Rinkeby
+
+Rinkeby is the public test network.
+
+```bash
+livepeer \
+    -network rinkeby
+    -ethUrl <ETH_URL> # URL for Rinkeby provider
+```
+
+### Private Network
+
+Custom private networks where the Livepeer smart contracts are deployed can be used for development purposes.
+
+```bash
+livepeer \
+    -network <NETWORK_NAME> # Name of network
+    -ethUrl <ETH_URL> # URL for private network provider
+    -ethController <CONTROLLER_ADDR> # Address of the Controller smart contract deployed on the private network
+```
+
+### Offchain
+
+Offchain networks that do not require interaction with the Livepeer smart contracts can be used for development purposes.
+
+```bash
+livepeer \
+    -network offchain
+```

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,132 @@
+# Install Livepeer
+
+- [Install Livepeer](#install-livepeer)
+  - [Install a binary release](#install-a-binary-release)
+  - [Install with Docker](#install-with-docker)
+  - [Install a binary pre-release](#install-a-binary-pre-release)
+  - [Build from source](#build-from-source)
+    - [System dependencies](#system-dependencies)
+    - [Go](#go)
+    - [Build and install](#build-and-install)
+  - [Build with Docker](#build-with-docker)
+
+## Install a binary release
+
+Find the latest release for your platform on the [releases page](https://github.com/livepeer/go-livepeer/releases). Linux, Darwin (macOS) and Windows are supported.
+
+```bash
+# <RELEASE_VERSION> is the release version i.e. 0.5.14
+# <YOUR_PLATFORM> is your platform i.e. linux, darwin, windows
+wget https://github.com/livepeer/go-livepeer/releases/download/<RELEASE_VERSION>/livepeer-<YOUR PLATFORM>-amd64.tar.gz
+tar -zxvf livepeer-<YOUR_PLATFORM>-amd64.tar.gz
+mv livepeer-<YOUR_PLATFORM>-amd64/* /usr/local/bin/
+```
+
+## Install with Docker
+
+Docker images are pushed to [DockerHub](https://hub.docker.com/r/livepeer/go-livepeer).
+
+```bash
+# <RELEASE_VERSION> is the release version i.e. 0.5.14
+docker pull livepeer/go-livepeer:<RELEASE_VERSION>
+```
+
+To pull the latest pre-release version:
+
+```bash
+docker pull livepeer/go-livepeer:master
+```
+
+## Install a binary pre-release
+
+Binaries are produced from every GitHub commit and download links are available in [the #builds channel of the Livepeer Discord server](https://discord.gg/drApskX).
+
+These binaries are produced from go-livepeer's CI process, shown in this diagram:
+
+![image](https://user-images.githubusercontent.com/257909/58923612-3709a800-86f5-11e9-838b-6202f296bce8.png)
+
+## Build from source
+
+### System dependencies 
+
+Building `livepeer` requires some system dependencies.
+
+Linux (Ubuntu: 16.04 or 18.04):
+
+```bash
+apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git curl
+# To enable transcoding on Nvidia GPUs
+apt-get -y install clang-8 clang-tools-8
+```
+
+Darwin (macOS):
+
+```bash
+brew update && brew install pkg-config autoconf gnutls
+```
+
+### Go
+
+Building `livepeer` requires Go. Follow the [official Go installation instructions](https://golang.org/doc/install).
+
+### Build and install
+
+1. Clone the repository:
+
+	```bash
+	git clone https://github.com/livepeer/go-livepeer.git
+	cd go-livepeer
+	```
+
+2. Install `ffmpeg` dependencies:
+
+	```bash
+	./install_ffmpeg.sh 
+	```
+
+3. Set build environment variables.
+
+	Set the `PKG_CONFIG_PATH` variable so that `pkg-config` can find the `ffmpeg` dependency files installed in step 2:
+
+	```bash
+	# install_ffmpeg.sh stores ffmpeg dependency files in this directory by default
+	export PKG_CONFIG_PATH=~/compiled/lib/pkgconfig
+	```
+
+	Set the `HIGHEST_CHAIN_TAG` variable to enable mainnet support:
+
+	```bash
+	export HIGHEST_CHAIN_TAG=mainnet
+	# To build with support for only development networks and the Rinkeby test network
+	# export HIGHEST_CHAIN_TAG=rinkeby
+	# To build with support for only development networks
+	# export HIGHEST_CHAIN_TAG=dev
+	```
+
+4. Build and install `livepeer`:
+
+	```bash
+	make
+	cp livepeer* /usr/local/bin
+	```
+
+## Build with Docker
+
+1. Clone the repository:
+
+	```bash
+	git clone https://github.com/livepeer/go-livepeer.git
+	cd go-livepeer
+	```
+
+2. Export tags:
+
+	```bash
+	echo $(git describe --tags) > .git.describe
+	```
+
+3. Build image:
+
+	```bash
+	docker build -t livepeerbinary:debian -f docker/Dockerfile.debian .
+	```

--- a/docs/video-miners/getting-started/index.md
+++ b/docs/video-miners/getting-started/index.md
@@ -4,7 +4,7 @@ This section will help video miners to:
 
 - Understand the [responsibilities of a video miner](./overview.md) and the different typers of miners that exist
 - Understand [hardware](../reference/hardware.md) and [bandwidth](../reference/bandwidth.md) requirements
-- [Install](https://github.com/livepeer/go-livepeer/blob/master/doc/install.md) the node software
+- [Install](../../install.md) the node software
 - [Connect](https://github.com/livepeer/go-livepeer/blob/master/doc/ethereum.md) to an Ethereum network
 - [Activate](./activate.md) on the network
 - [Test](./test.md) to ensure they can receive work on the network

--- a/docs/video-miners/getting-started/index.md
+++ b/docs/video-miners/getting-started/index.md
@@ -5,6 +5,6 @@ This section will help video miners to:
 - Understand the [responsibilities of a video miner](./overview.md) and the different typers of miners that exist
 - Understand [hardware](../reference/hardware.md) and [bandwidth](../reference/bandwidth.md) requirements
 - [Install](../../install.md) the node software
-- [Connect](https://github.com/livepeer/go-livepeer/blob/master/doc/ethereum.md) to an Ethereum network
+- [Connect](../../ethereum.md) to an Ethereum network
 - [Activate](./activate.md) on the network
 - [Test](./test.md) to ensure they can receive work on the network


### PR DESCRIPTION
Also updates links in video miners getting started to point to top level guides instead of external resources. We'll eventually use these top level guides as the single source of truth for these things.