### PR TITLE
Fix total active nodes on video miners page

### DIFF
--- a/components/sections/video-miners/let-the-numbers-talk.tsx
+++ b/components/sections/video-miners/let-the-numbers-talk.tsx
@@ -6,6 +6,7 @@ import { nFormatter } from "lib/document-helpers";
 const LetTheNumbersTalkSection = ({
   title,
   subtitle,
+  totalActiveNodes,
   totalVolume,
   label1,
   label2,
@@ -13,7 +14,7 @@ const LetTheNumbersTalkSection = ({
 }) => {
   const stats: StatProps[] = [
     {
-      title: "45",
+      title: totalActiveNodes,
       label: label1,
     },
     {

--- a/lib/document-helpers.ts
+++ b/lib/document-helpers.ts
@@ -81,6 +81,24 @@ const getTotalVolume = async () => {
   return totalVolumeUSD;
 };
 
+const getTotalActiveNodes = async () => {
+  const query = `query transcoders ($where: Transcoder_filter) {
+    transcoders(where: $where) {
+      id
+    }
+  }`;
+  let response = await request(
+    "https://api.thegraph.com/subgraphs/name/livepeer/livepeer",
+    query,
+    {
+      where: {
+        active: true,
+      },
+    }
+  );
+  return response.transcoders.length;
+};
+
 const getTotalDelegators = async () => {
   const PAGE_SIZE = 100;
   const reqDelegators = async (skip) => {
@@ -123,4 +141,5 @@ export {
   getTotalActiveStake,
   getTotalDelegators,
   getTotalVolume,
+  getTotalActiveNodes,
 };

--- a/pages/video-miners.tsx
+++ b/pages/video-miners.tsx
@@ -4,12 +4,12 @@ import LetTheNumbersTalkSection from "components/sections/video-miners/let-the-n
 import HowToGetStartedSection from "components/sections/video-miners/how-to-get-started";
 import RequirementsSection from "components/sections/video-miners/requirements";
 import VideoMinerHero from "components/sections/video-miners/hero";
-import { getTotalVolume } from "lib/document-helpers";
+import { getTotalVolume, getTotalActiveNodes } from "lib/document-helpers";
 import { HeadProps } from "components/primitives/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 
-const VideoMinerPage = ({ totalVolume }) => {
+const VideoMinerPage = ({ totalVolume, totalActiveNodes }) => {
   const { t } = useTranslation(["video-miners", "developers", "common"]);
 
   const headProps: HeadProps = {
@@ -40,6 +40,7 @@ const VideoMinerPage = ({ totalVolume }) => {
         label1={t("page-video-miners-numbers-nodes-text")}
         label2={t("page-video-miners-numbers-fees-text")}
         label3={t("page-video-miners-numbers-cost-text")}
+        totalActiveNodes={totalActiveNodes}
         totalVolume={totalVolume}
       />
       <RequirementsSection
@@ -71,10 +72,12 @@ const VideoMinerPage = ({ totalVolume }) => {
 
 export async function getStaticProps({ locale }) {
   const totalVolume = await getTotalVolume();
+  const totalActiveNodes = await getTotalActiveNodes();
 
   return {
     props: {
       totalVolume,
+      totalActiveNodes,
       ...(await serverSideTranslations(locale, [
         "common",
         "video-miners",


### PR DESCRIPTION
This PR fixes the total active nodes on the video miners page by fetching this data from the subgraph. 

Note: this number includes nodes who are pending activation if there are any, but I think this is okay. Once [this issue](https://github.com/livepeer/livepeerjs/issues/929) is resolved this number will reflect only current active nodes.

Close #81 