### PR TITLE
-ethURL >>> -ethUrl

### DIFF
--- a/docs/video-miners/getting-started/activation.mdx
+++ b/docs/video-miners/getting-started/activation.mdx
@@ -39,7 +39,7 @@ Start your orchestrator before activation:
 ```bash
 livepeer \
     -network mainnet \
-    -ethURL <ETH_URL> \
+    -ethUrl <ETH_URL> \
     -ethAcctAddr <ETH_ACCT_ADDR> \ # Only required if you already have an ETH account you want to use
     -orchestrator \
     -transcoder \


### PR DESCRIPTION
Current version of docs gives incorrect capitalisation for `-ethUrl` which resulted in this forum post: https://forum.livepeer.org/t/ethurl-command-not-found/1337

![image](https://user-images.githubusercontent.com/2212651/115995451-df31fe00-a5f8-11eb-8849-c6bc1f089a59.png)
