### PR TITLE
Highlight that the amount to stake is in LPTU

### DIFF
--- a/docs/video-miners/getting-started/activation.mdx
+++ b/docs/video-miners/getting-started/activation.mdx
@@ -165,8 +165,8 @@ Once you have your orchestrator running, you can activate using `livepeer_cli`.
    Enter bond amount - >
    ```
 
-   Since the amount is denominated in LPTU, if you want to bond 5 LPT, you would
-   enter 5000000000000000000.
+   **Important note:** This amount is denominated in LPTU, so if you want to bond 5 LPT,
+   you would enter 5000000000000000000.
 
    If the active orchestrator set is full (i.e. at 100), the minimum stake you
    need to stake to activate is the lowest total stake of an orchestrator in the


### PR DESCRIPTION
Community members adrianm and Twodawg both reported in Livepeer Discord that they found the LPTU vs. LPT distinction confusing, and that they unnecessarily burned gas.

![image](https://user-images.githubusercontent.com/2212651/124290567-344a3d00-db71-11eb-871d-f1b07dfd557a.png)

This PR seeks to highlight this point, by adding a bold "Important note:" text, so that others are more likely to see it, and avoid wasting gas.