### PR TITLE
remove gnutls from installation instructions

### DIFF
--- a/docs/installation/install-livepeer.mdx
+++ b/docs/installation/install-livepeer.mdx
@@ -54,7 +54,7 @@ Building `livepeer` requires some system dependencies.
 Linux (Ubuntu: 16.04 or 18.04):
 
 ```bash
-apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git curl
+apt-get update && apt-get -y install build-essential pkg-config autoconf git curl
 # To enable transcoding on Nvidia GPUs
 apt-get -y install clang-8 clang-tools-8
 ```
@@ -62,7 +62,7 @@ apt-get -y install clang-8 clang-tools-8
 Darwin (macOS):
 
 ```bash
-brew update && brew install pkg-config autoconf gnutls
+brew update && brew install pkg-config autoconf
 ```
 
 Windows:


### PR DESCRIPTION
gnutls no longer needed since livepeer/go-livepeer@9b40b9404b8db38e7098d29d058839fd725b96cc