### PR TITLE
Update help descriptions for {min,max}GasPrice

### DIFF
--- a/docs/video-miners/reference/configuration.mdx
+++ b/docs/video-miners/reference/configuration.mdx
@@ -94,9 +94,9 @@ maxTxReplacements: Number of times to automatically replace pending Ethereum tra
 
 gasLimit: Gas limit for ETH transaction. Default `0`
 
-minGasPrice: Minimum gas price (priority fee + base fee) for ETH transactions in wei, 10 Gwei = 10000000000. Default `0`
+minGasPrice: Minimum gas price (priority fee + base fee) for Arbitrum-ETH transactions in ArbGas
 
-maxGasPrice: Maximum gas price (priority fee + base fee) for ETH transactions in wei, 40 Gwei = 40000000000. Default `0`
+maxGasPrice: Maximum gas price (priority fee + base fee) for Arbitrum-ETH transactions in ArbGas
 
 ethController: Protocol smart contract address. No default
 


### PR DESCRIPTION
This is no longer in Wei, Arbitrum calls it ArbGas - https://developer.offchainlabs.com/docs/arbgas
Should we be suggesting a min or max gas price in the help on L2?