### PR TITLE
docs: Fix monitoring docker file link

### DIFF
--- a/docs/video-miners/how-to-guides/metrics-monitoring.mdx
+++ b/docs/video-miners/how-to-guides/metrics-monitoring.mdx
@@ -33,7 +33,7 @@ The metrics recorded by `livepeer` can be exported to
 ## Monitoring with the livepeer monitoring container
 
 A
-[Docker container](https://github.com/livepeer/docker-livepeer/tree/master/monitoring)
+[Docker container](https://hub.docker.com/r/livepeer/monitoring)
 that bundles Prometheus, Grafana and a few starter Grafana dashboard templates
 can also be used.
 


### PR DESCRIPTION
Currently pointing to a filepath that doesn't exist, so replacing with a link to the actual docker image