### PR TITLE
docs: archive repo in favor of livepeer/website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # livepeer.org
 
+> [!WARNING]
+> **This repository is archived.** It has been replaced by
+> [livepeer/website](https://github.com/livepeer/website).
+
 Livepeer.org is a primary online resource for participants and users of the
 Livepeer network. It includes:
 


### PR DESCRIPTION
## Summary
- Adds a GitHub warning admonition to the README indicating this repository is archived
- Points contributors to its replacement at [livepeer/website](https://github.com/livepeer/website)

## Test plan
- [x] Verify the admonition renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)